### PR TITLE
Include simplified "comment" in the task event schema

### DIFF
--- a/subscriptions/schemas/taskEventSchema.json
+++ b/subscriptions/schemas/taskEventSchema.json
@@ -110,6 +110,23 @@
                 "anyOf": [{ "type": "string" }, { "type": "null" }]
               }
             }
+          },
+          "comment": {
+            "type": "object",
+            "description": "Comment information",
+            "properties": {
+              "date": { "type": "string" },
+              "id": { "type": "string" },
+              "text_content": { "type": "string" },
+              "user": {
+                "type": "object",
+                "properties": {
+                  "email": { "type": "string" },
+                  "id": { "type": "number" },
+                  "username": { "type": "string" }
+                }
+              }
+            }
           }
         }
       }


### PR DESCRIPTION
This PR adds simplified version of the `comment` object that may be available in the history items. Next task is to ask Clickup's support team to provide full JSON schema for the task event payload, so we can fill in everything else.